### PR TITLE
Remove QUIT command sending

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -34,8 +34,6 @@ listen redis-read
     tcp-check expect string role:slave
     #tcp-check send PING\r\n
     #tcp-check expect string +PONG
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server redis-1 <ip>:<port> maxconn 5000 check inter 2s
     server redis-2 <ip>:<port> maxconn 5000 check inter 2s
     server redis-3 <ip>:<port> maxconn 5000 check inter 2s
@@ -63,8 +61,6 @@ backend redis-master-1
     tcp-check expect string +OK
     tcp-check send info\ replication\r\n
     tcp-check expect string role:master
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server redis <ip>:<port> maxconn 5000 check inter 2s
 
 backend redis-master-2
@@ -76,8 +72,6 @@ backend redis-master-2
     tcp-check expect string +OK
     tcp-check send info\ replication\r\n
     tcp-check expect string role:master
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server redis <ip>:<port> maxconn 5000 check inter 2s
 
 backend redis-master-3
@@ -89,8 +83,6 @@ backend redis-master-3
     tcp-check expect string +OK
     tcp-check send info\ replication\r\n
     tcp-check expect string role:master
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server redis <ip>:<port> maxconn 5000 check inter 2s
 
 #Following 3 backends tells if sentinels identify the 3 redis servers as masters
@@ -99,8 +91,6 @@ backend mastercheck-redis-1
     option tcp-check
     tcp-check send SENTINEL\ master\ <your-master-name>\r\n
     tcp-check expect string <ip-of-redis-server-1>
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server sentinel-1 <ip>:<port> check inter 2s
     server sentinel-2 <ip>:<port> check inter 2s
     server sentinel-3 <ip>:<port> check inter 2s
@@ -110,8 +100,6 @@ backend mastercheck-redis-2
     option tcp-check
     tcp-check send SENTINEL\ master\ <your-master-name>\r\n
     tcp-check expect string <ip-of-redis-server-2>
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server sentinel-1 <ip>:<port> check inter 2s
     server sentinel-2 <ip>:<port> check inter 2s
     server sentinel-3 <ip>:<port> check inter 2s
@@ -121,8 +109,6 @@ backend mastercheck-redis-3
     option tcp-check
     tcp-check send SENTINEL\ master\ <your-master-name>\r\n
     tcp-check expect string <ip-of-redis-server-3>
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server sentinel-1 <ip>:<port> check inter 2s
     server sentinel-2 <ip>:<port> check inter 2s
     server sentinel-3 <ip>:<port> check inter 2s
@@ -137,8 +123,6 @@ backend redis-legacy
     tcp-check expect string +OK
     tcp-check send info\ replication\r\n
     tcp-check expect string role:master
-    tcp-check send QUIT\r\n
-    tcp-check expect string +OK
     server redis-1 <ip>:<port> maxconn 5000 check inter 2s
     server redis-2 <ip>:<port> maxconn 5000 check inter 2s
     server redis-3 <ip>:<port> maxconn 5000 check inter 2s


### PR DESCRIPTION
The `QUIT` command has been deprecated in 7.2.0 (cf. [docs](https://redis.io/docs/latest/commands/quit/)) and is no longer working in 7.4 (perhaps even in 7.3, didn't check that version).

As stated in the docs:
> Clients should not use this command. Instead, clients should simply close the connection when they're not used anymore. Terminating a connection on the client side is preferable, as it eliminates TIME_WAIT lingering sockets on the server side.

When testing your config, the masterchecks were all failing. When removing the `QUIT` command, they worked as expected 😀